### PR TITLE
Integrate JSON API for SEDAR+ recent filings and store PDFs in DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,48 @@
 
 ## Features
 - **Issuer Data**: Fetches and stores a complete list of Canadian reporting issuers.
-- **Filing Metadata**: Retrieves metadata for all public filings.
+- **Filing Metadata**: Retrieves metadata for public filings.
+    - **Incremental Updates (JSON API)**: Uses SEDAR+'s `searchDocuments` JSON API to fetch recent filings, including direct PDF URLs.
+    - **Historical Backfill (CSV Export)**: Uses SEDAR+'s CSV export feature for bulk fetching of historical filing metadata.
+- **PDF Document Storage**:
+    - For incremental updates, downloads PDF documents and stores their raw byte content directly in the `filings.pdf_data` database column.
+    - For historical backfill, continues to download PDFs to the local file system (`data/pdfs/`).
 - **Filing Inventory**: Processes the manually downloaded "Filing Inventory" Excel file to map document categories and types.
-- **Document Downloads**: Automates the download of PDF documents associated with filings.
-- **Supabase Integration**: Optionally uploads and synchronizes data with a Supabase PostgreSQL database.
-- **Local Caching**: Caches fetched data (issuers, filings, document types) locally to minimize redundant downloads and API calls.
+- **Supabase Integration**: Optionally uploads and synchronizes data with a Supabase PostgreSQL database, including the new `filings` table with embedded PDF data.
+- **Local Caching**: Caches fetched data (issuers, CSV-based filings, document types) locally to minimize redundant downloads and API calls.
 - **Rate Limiting**: Implements configurable delays between requests to SEDAR+ to ensure respectful data collection.
 - **Retry Logic**: Automatically retries failed network requests.
 - **Workflow Functions**:
     - `update_reference_data()`: Updates issuer information and document type definitions from the Filing Inventory.
-    - `run_incremental_update()`: Fetches recent filings and their associated documents for a specified number of days.
-    - `run_historical_backfill()`: Allows for bulk collection of filings and documents for a specified historical date range.
+    - `run_incremental_update()`: Fetches recent filings (using JSON API), downloads their PDFs directly into the database, for a specified number of recent days. This is the primary method for ongoing data collection.
+    - `run_historical_backfill()`: Allows for bulk collection of filings (CSV based) and documents (to local filesystem) for a specified historical date range.
 - **Logging**: Comprehensive logging of script activities, errors, and progress.
+
+## Revised Data Collection (JSON API and PDF Storage) - For Incremental Updates
+
+The `sedar_collector.py` script has been enhanced for incremental updates to use a more direct and robust method for fetching recent filings and their PDF documents:
+
+1.  **JSON API for Recent Filings**: Instead of relying on daily CSV exports for recent data, the `run_incremental_update` function now queries the SEDAR+ `searchDocuments` JSON API. This provides more structured metadata directly from the source.
+2.  **Direct PDF Download to Database**:
+    *   For each filing retrieved via the JSON API, the script attempts to download the associated PDF document.
+    *   The raw binary content (bytes) of the PDF is then stored in the `pdf_data` column (type `BYTEA`) of the new `filings` table in the Supabase database.
+    *   This approach keeps the metadata and the actual document data together in the database, simplifying data management for recent filings.
+3.  **`filings` Table**: A new table schema is defined in `new_filings_schema.sql` for this purpose.
+    *   **Key Columns**:
+        *   `filing_id` (UUID, Primary Key)
+        *   `issuer_no` (TEXT)
+        *   `document_guid` (TEXT, Unique): Crucial for identifying and de-duplicating filings.
+        *   `date_filed` (DATE)
+        *   `filing_type` (TEXT)
+        *   `document_type` (TEXT)
+        *   `size_bytes` (BIGINT)
+        *   `pdf_data` (BYTEA): Stores the raw binary content of the downloaded PDF.
+4.  **Benefits**:
+    *   More reliable data fetching for recent items.
+    *   Consolidated storage of metadata and PDF content for easier access and analysis.
+    *   Reduced reliance on parsing CSV files for the most current data.
+
+The historical backfill (`run_historical_backfill`) continues to use the CSV export method and saves PDFs to the local filesystem, as this is more suitable for very large historical data pulls.
 
 ## Prerequisites
 - Python 3.7+
@@ -45,14 +75,10 @@
 3.  **Environment Variables**:
     Create a `.env` file in the root of the project directory by copying `example.env` (if provided) or creating a new one. Populate it with the following variables:
 
-    *   `SEDAR_BASE_URL`: The base URL for the SEDAR+ API.
-        *   Default: `https://www.sedarplus.ca`
-        *   Purpose: Specifies the SEDAR+ service endpoint.
-    *   `SUPABASE_URL`: (Optional) Your Supabase project URL.
-        *   Purpose: Enables data synchronization with your Supabase database. If not provided, data is only stored locally.
-    *   `SUPABASE_KEY`: (Optional) Your Supabase project API key (anon or service role).
-        *   Purpose: Authenticates with your Supabase project.
-    *   `SUPABASE_SCHEMA`: (Optional) The Supabase database schema to use.
+    *   `SEDAR_BASE_URL`: The base URL for the SEDAR+ API (e.g., `https://www.sedarplus.ca`). **Required.**
+    *   `SUPABASE_URL`: Your Supabase project URL. **Required if using Supabase integration.**
+    *   `SUPABASE_KEY`: Your Supabase project API key (anon or service role). **Required if using Supabase integration.**
+    *   `SUPABASE_SCHEMA`: The Supabase database schema to use.
         *   Default: `public`
         *   Purpose: Specifies the target schema in your Supabase database.
     *   `RATE_LIMIT_DELAY`: Delay in seconds between consecutive requests to SEDAR+.
@@ -100,14 +126,23 @@ Execute the script from the project's root directory:
 python sedar_collector.py
 ```
 
-By default, the `main()` function in `sedar_collector.py` currently performs the following actions:
-1.  Calls `collector.update_reference_data()`: This fetches the latest issuer data from SEDAR+ and processes the local `Filing_Inventory.xlsx` file. Results are saved to `reference_update_results_{timestamp}.json` in the cache directory.
-2.  The call to `collector.run_incremental_update()` might be commented out by default in `main()`. If you wish to run it, you can uncomment it. This function fetches filings for the last 7 days (by default).
+By default, the `main()` function in `sedar_collector.py` performs the following actions:
+1.  Calls `collector.update_reference_data()`: This fetches the latest issuer data from SEDAR+ and processes the local `Filing_Inventory.xlsx` file.
+2.  Calls `collector.run_incremental_update(days_back=2)`: This fetches recent filings for the last 2 days (today and yesterday) using the new JSON API method, downloads their PDFs, and stores them in the `filings` table in Supabase.
+
+**Scheduling the Script**:
+As noted in `sedar_collector.py`, the script is designed for regular execution to keep your data current.
+-   Use cron (Linux/macOS), Windows Task Scheduler, or a workflow orchestrator (e.g., Apache Airflow).
+-   Example cron job to run every 15 minutes:
+    ```cron
+    */15 * * * * /path/to/your_virtualenv/bin/python /path/to/sedar_collector.py >> /path/to/sedar_collector_cron.log 2>&1
+    ```
+-   Ensure environment variables (`SUPABASE_URL`, `SUPABASE_KEY`, etc.) are available to the execution environment.
 
 **Output Data Storage**:
 *   **Logs**: Script activities and errors are logged to `sedar_collector.log` and also printed to the console.
-*   **Cached Files**: CSV files for issuers, filings, and processed filing inventory are stored in `data/cache/`.
-*   **Downloaded PDFs**: PDF documents are saved in `data/pdfs/`.
+*   **Cached Files**: CSV files for issuers, historical filings, and processed filing inventory are stored in `data/cache/`.
+*   **Downloaded PDFs (Historical)**: PDF documents from `run_historical_backfill` are saved in `data/pdfs/`. PDFs from `run_incremental_update` are stored directly in the database.
 *   **Results Files**: JSON files summarizing the outcomes of operations like `update_reference_data` or `run_incremental_update` are saved in `data/cache/`.
 
 ## Workflow Functions
@@ -115,46 +150,50 @@ By default, the `main()` function in `sedar_collector.py` currently performs the
 The `SedarCollector` class provides several main workflow methods:
 
 *   **`update_reference_data()`**:
-    *   **Purpose**: Fetches and updates essential reference datasets.
-    *   It retrieves the latest list of all reporting issuers from SEDAR+.
-    *   It processes the `Filing_Inventory.xlsx` file (which you must manually download and place in `data/reference/`) to update the database with document types, categories, and access levels.
-    *   This function should be run periodically to keep your issuer and document type information current.
+    *   **Purpose**: Fetches and updates essential reference datasets (issuers, document types from `Filing_Inventory.xlsx`).
+    *   Run periodically to keep reference information current.
 
-*   **`run_incremental_update(days_back: int = 7)`**:
-    *   **Purpose**: Collects recent filings and their associated documents.
+*   **`run_incremental_update(days_back: int = 2)`**:
+    *   **Purpose**: Collects recent filings using the JSON API and stores them with their PDF content in the database.
     *   Fetches filing metadata for the last `days_back` days.
-    *   Downloads the PDF documents for these filings.
-    *   Ideal for regular, automated runs (e.g., daily) to keep your dataset up-to-date.
+    *   Downloads the PDF documents and stores their byte data in the `filings.pdf_data` column.
+    *   This is the **primary method for ongoing, automated data collection**.
 
 *   **`run_historical_backfill(start_date: str, end_date: str, chunk_days: int = 30)`**:
-    *   **Purpose**: Performs bulk collection of filings and documents for a specified historical period.
-    *   Fetches filing metadata in chunks of `chunk_days` to manage large data volumes.
-    *   Downloads associated PDF documents.
-    *   Useful for initially populating your database or collecting data for specific historical research.
+    *   **Purpose**: Performs bulk collection of filings (CSV-based) and documents (to local filesystem) for a specified historical period.
+    *   Useful for initially populating your database or collecting data for specific historical research where PDFs are stored locally.
 
 ## Database Schema
 
-If Supabase is configured, the script will attempt to store data in a PostgreSQL database adhering to the schema defined in `database_schema.sql`.
+If Supabase is configured, the script interacts with a PostgreSQL database. The schema is primarily defined in two files:
 
-**Key Tables**:
-*   `public.dim_issuer`: Stores detailed information about each reporting issuer (e.g., name, jurisdiction, type). Primary Key: `issuer_no`.
-*   `public.dim_document_type`: Stores information about filing categories, filing types, and document types, sourced from the `Filing_Inventory.xlsx`. Primary Key: `document_type_id` (surrogate), Unique Constraint: (`filing_category`, `filing_type`, `document_type`).
-*   `public.fact_filing`: Contains metadata for each individual filing (e.g., issuer, document GUID, submission date, download URL, size). Primary Key: `filing_id` (UUID), Unique Constraint: `document_guid`.
+1.  **`new_filings_schema.sql`**:
+    *   Defines the **`filings` table**, which is central to the new data collection approach.
+    *   **Key columns**: `filing_id` (PK), `issuer_no`, `document_guid` (Unique), `date_filed`, `filing_type`, `document_type`, `size_bytes`, and `pdf_data` (BYTEA).
+    *   This table stores metadata for filings fetched via the JSON API and embeds their PDF content directly in the `pdf_data` column.
 
-Other tables like `fact_statement_line`, `fact_insider_tx`, `mart_sentiment`, etc., are defined in `database_schema.sql` for potential future extensions (e.g., NLP analysis, financial data extraction).
+2.  **`database_schema.sql`**:
+    *   Defines other related tables used by the system, such as:
+        *   `public.dim_issuer`: Stores detailed information about each reporting issuer.
+        *   `public.dim_document_type`: Stores information about filing categories and types from `Filing_Inventory.xlsx`.
+        *   `public.fact_filing`: This table was previously used for all filing metadata. While `run_historical_backfill` might still interact with it or a similar structure for CSV-based data, new incremental filings with embedded PDFs go into the `filings` table defined in `new_filings_schema.sql`. The system might evolve to consolidate these, but for now, they serve distinct data ingestion paths.
+    *   It also includes placeholder tables for future extensions (e.g., `fact_statement_line`, `mart_sentiment`).
+
+**Note on Data Flow**:
+-   **Recent Filings (Incremental)**: `searchDocuments` JSON API -> `SedarCollector.fetch_recent_filings_json()` -> `SedarCollector.download_pdf_to_bytes()` -> `SedarCollector.insert_filing_with_pdf()` -> `filings` table (with `pdf_data`).
+-   **Historical Filings (Bulk)**: CSV Export -> `SedarCollector.fetch_filings_for_date_range()` -> (PDFs to local disk via `download_documents_batch`) -> `dim_issuer`, `fact_filing` (metadata only, PDF path might be stored if adapted).
 
 ## Data Storage
 
 *   **Local Cache (`data/cache/`)**:
     *   `issuers_{timestamp}.csv`: Raw list of issuers from SEDAR+.
-    *   `filings_{start_date}_{end_date}.csv`: Raw list of filings for a given period.
+    *   `filings_{start_date}_{end_date}.csv`: Raw list of *historical* filings for a given period (CSV based).
     *   `filing_inventory.csv`: Processed data from `Filing_Inventory.xlsx`.
-    *   `issuers_processed.csv`: Issuers data prepared for Supabase (if Supabase is off).
-    *   `filings_processed.csv`: Filings data prepared for Supabase (if Supabase is off).
-    *   `document_types_processed.csv`: Document types data prepared for Supabase (if Supabase is off).
-    *   `*_results_{timestamp}.json`: JSON files detailing the outcome of major operations.
-*   **PDF Downloads (`data/pdfs/`)**: Stores downloaded PDF documents, named by their `Document GUID`.
-*   **Supabase (Optional)**: If `SUPABASE_URL` and `SUPABASE_KEY` are provided, the script will attempt to upsert data into the tables defined in `database_schema.sql`.
+    *   Results files for operations (`*_results_{timestamp}.json`).
+*   **PDF Downloads (`data/pdfs/`)**: Stores PDF documents downloaded by the `run_historical_backfill` process. PDFs from `run_incremental_update` are now stored in the database.
+*   **Supabase Database**:
+    *   **`filings` table**: Stores recent filings with embedded PDF data (from `run_incremental_update`).
+    *   Other tables like `dim_issuer`, `dim_document_type`, and potentially an older `fact_filing` table for historical CSV-based metadata.
 
 ## Compliance and Best Practices
 
@@ -168,11 +207,11 @@ Other tables like `fact_statement_line`, `fact_insider_tx`, `mart_sentiment`, et
     *   This means the script could not find `data/reference/Filing_Inventory.xlsx`.
     *   Ensure you have manually downloaded this file from SEDAR+ and placed it in the correct directory with the correct name. See the "Manual Setup - Filing Inventory" section.
 *   **Supabase Connection Errors**:
-    *   Verify that `SUPABASE_URL` and `SUPABASE_KEY` in your `.env` file are correct.
+    *   Verify that `SUPABASE_URL` and `SUPABASE_KEY` in your `.env` file are correct and that they are accessible to the script's execution environment (especially for cron jobs).
     *   Check your Supabase project status and network connectivity.
-    *   Ensure the tables defined in `database_schema.sql` have been created in your Supabase database.
+    *   Ensure the tables defined in `database_schema.sql` and `new_filings_schema.sql` have been created in your Supabase database.
 *   **Permission Errors**:
-    *   Ensure the script has write permissions for the `data/` directory (and its subdirectories: `cache/`, `reference/`, `pdfs/`) and for `sedar_collector.log`.
+    *   Ensure the script has write permissions for the `data/` directory (and its subdirectories: `cache/`, `reference/`, `pdfs/` if still used by historical runs) and for `sedar_collector.log`.
 *   **Rate Limiting Issues (429 Errors)**:
     *   If you encounter errors related to too many requests, increase the `RATE_LIMIT_DELAY` in your `.env` file.
 

--- a/new_filings_schema.sql
+++ b/new_filings_schema.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS filings (
+  filing_id    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  issuer_no    TEXT NOT NULL,
+  document_guid TEXT UNIQUE NOT NULL,
+  date_filed   DATE NOT NULL,
+  filing_type  TEXT,
+  document_type TEXT,
+  size_bytes   BIGINT,
+  pdf_data     BYTEA       -- stores the raw PDF
+);


### PR DESCRIPTION
This commit revamps the data collection process for recent SEDAR+ filings. Key changes include:

1.  **New `searchDocuments` API Integration**:
    *   The `SedarCollector` now uses the `/csa-party/service/searchDocuments`
        endpoint, which returns JSON, for fetching daily filings. This
        replaces the previous CSV export method for incremental updates,
        aiming for better reliability.
    *   A new method `fetch_recent_filings_json` handles this API interaction.

2.  **Direct PDF Content Storage**:
    *   A new table schema is defined in `new_filings_schema.sql` for a
        table named `filings`. This table includes a `pdf_data BYTEA`
        column to store raw PDF document bytes.
    *   The `download_pdf_to_bytes` method fetches PDF content into memory.
    *   The `insert_filing_with_pdf` method upserts filing metadata along
        with the PDF bytes into the `filings` table.

3.  **Updated Incremental Collection**:
    *   The `run_incremental_update` method in `sedar_collector.py` has
        been overhauled to use the new JSON fetching and PDF byte storage
        workflow.
    *   The main execution logic in `main()` now calls this updated method.

4.  **Documentation and Configuration**:
    *   The `README.md` has been updated to explain the new data
        collection approach, the `filings` table structure, and PDF
        storage.
    *   Guidance on scheduling the script via cron or similar tools has
        been added as comments in `sedar_collector.py`.

This revised approach allows for more robust capture of recent filings and stores the PDF documents directly within the Supabase database, which bypasses issues related to CSV parsing and local file management for the primary collection task.